### PR TITLE
Update api and kick players if their signature expires.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
   </build>
 <repositories>
     <repository>
-        <id>velocity</id>
-        <url>https://nexus.velocitypowered.com/repository/maven-public/</url>
+        <id>papermc</id>
+        <url>https://repo.papermc.io/repository/maven-public/</url>
     </repository>
 </repositories>
 
@@ -38,7 +38,7 @@
     <dependency>
         <groupId>com.velocitypowered</groupId>
         <artifactId>velocity-api</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.2-SNAPSHOT</version>
         <scope>provided</scope>
     </dependency>
 </dependencies>

--- a/src/de/flori4nk/velocityautoreconnect/listeners/KickListener.java
+++ b/src/de/flori4nk/velocityautoreconnect/listeners/KickListener.java
@@ -53,14 +53,22 @@ public class KickListener {
 
             Player player = event.getPlayer();
 
+            // Get the kick reason, when possible. Use an empty Component if the kick reason isn't present.
+            Component kickReason = event.getServerKickReason().isPresent() ? event.getServerKickReason().get() : Component.empty();
+            String kickReasonText;
+
+            if (player.getIdentifiedKey() != null) {
+                if (player.getIdentifiedKey().hasExpired()) {
+                    player.disconnect(kickReason);
+                    VelocityAutoReconnect.getLogger().info("Player (" + player.getUsername() + ") got kicked for invalid signature");
+                    return;
+                }
+            }
+
             if (VelocityAutoReconnect.getConfigurationManager().getBooleanProperty("bypasscheck")
                     && player.hasPermission("velocityautoreconnect.bypass")) {
                 return;
             }
-
-            // Get the kick reason, when possible. Use an empty Component if the kick reason isn't present.
-            Component kickReason = event.getServerKickReason().isPresent() ? event.getServerKickReason().get() : Component.empty();
-            String kickReasonText;
 
             if (kickReason instanceof TranslatableComponent) {
                 kickReasonText = ((TranslatableComponent) kickReason).key();


### PR DESCRIPTION
Added a check to kick players when their signature becomes invalid (1.19 - 1.19.1)

I had a problem with players blocking others from reconnecting from Limbo -> Main cause their signature expired so Main wouldn't authenticate them but going from Main -> Limbo nanolimbo doesn't make this check and kick them from the network.

Anyway this check resolves the issue and kicks people from Velocity when their signature expires.