### PR TITLE
"ping-worldloaded-check" setting to avoid flood of "Connecting username to server" log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ After following the installation guide, edit the configuration file: ``plugins/v
 * Default: true
 * Description: Whether VelocityAutoReconnect should check if a server responds to pings before trying to connect a player to it.
 
+**ping-worldloaded-check**
+* Default: true
+* Description: Whether VelocityAutoReconnect should prevent the flood of "Connecting name to server" messages during the "Preparing spawn area" phase of your lobby / main server loading by checking if the server is able to establish a connection.
+
 **bypasscheck** (>=1.3.0)
 * Default: false
 * Description: Whether VelocityAutoReconnect should not reconnect players with the ``velocityautoreconnect.bypass`` permission.

--- a/src/de/flori4nk/velocityautoreconnect/VelocityAutoReconnect.java
+++ b/src/de/flori4nk/velocityautoreconnect/VelocityAutoReconnect.java
@@ -116,9 +116,17 @@ public class VelocityAutoReconnect {
             try {
                 if (configurationManager.getBooleanProperty("pingcheck")) {
                     try {
-                        previousServer.ping().join();
+                        // Check if server is up
+                        var pingResult = previousServer.ping().join();
+
+                        // This part of code can execute only if server responded with a ping.
+                        // We have to check if pingResult is not empty, because Minecraft server
+                        // actually responds to a pings even on the "Preparing spawn area" loading phase.
+                        // During that phase it is impossible to join the server to make sure that we
+                        // aren't flooding logs with the "Connecting someone to something" messages.
+                        if (configurationManager.getBooleanProperty("ping-worldloaded-check") && !(pingResult.getVersion() != null || pingResult.getPlayers().isPresent() || pingResult.getModinfo().isPresent() || pingResult.getDescriptionComponent() != null)) return;
                     } catch (CompletionException completionException) {
-                        // Server failed to respond to ping request, return to prevent spam
+                        // Server failed to respond to ping request, return to prevent flood
                         return;
                     }
                 }

--- a/src/de/flori4nk/velocityautoreconnect/storage/ConfigurationManager.java
+++ b/src/de/flori4nk/velocityautoreconnect/storage/ConfigurationManager.java
@@ -42,6 +42,7 @@ public class ConfigurationManager {
             this.properties.setProperty("directconnect-server", "lobby");
             this.properties.setProperty("task-interval-ms", "3500");
             this.properties.setProperty("pingcheck", "true");
+            this.properties.setProperty("ping-worldloaded-check", "true");
             this.properties.setProperty("bypasscheck", "false");
             this.properties.setProperty("kick-filter.blacklist", ".* ([Bb]anned|[Kk]icked|[Ww]hitelist).*");
             this.properties.setProperty("kick-filter.blacklist.enabled", "true");


### PR DESCRIPTION
This PR introduces a new setting called `ping-worldloaded-check` to prevent flooding of Velocity's logs with unnecessary "Connecting username to server" messages during the "Preparing spawn area" world loading phase on the 'main' server. To determine whether the 'main' server is fully loaded, this setting checks the data contained in the server's ping response, such as the game version, player count, or mod information.

During the "Preparing spawn area" phase, the Minecraft server sends a ping in which all of these fields are null, allowing the `ping-worldloaded-check` setting to identify when it is not possible to connect a player to the server.