### PR TITLE
"message" setting JSON text support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ After following the installation guide, edit the configuration file: ``plugins/v
 ##### Fallback Message
 **message**
 * Default: You will be reconnected soon.
-* Description: Welcome message sent to players joining the Limbo server
+* Description: Welcome message sent to players joining the Limbo server. Can be a JSON Text Component.
 
 **message.enabled**
 * Default: false

--- a/src/de/flori4nk/velocityautoreconnect/misc/Utility.java
+++ b/src/de/flori4nk/velocityautoreconnect/misc/Utility.java
@@ -21,21 +21,26 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import de.flori4nk.velocityautoreconnect.VelocityAutoReconnect;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 
 import java.util.Optional;
 
 public class Utility {
 
-    // Returns whether or not the names of the servers match.
+    // Returns whether the names of the servers match.
     public static boolean doServerNamesMatch(RegisteredServer var0, RegisteredServer var1) {
         return var0.getServerInfo().getName().equals(var1.getServerInfo().getName());
     }
 
-    // Check whether or not the welcome message should be sent and act accordingly
+    // Check whether the welcome message should be sent and act accordingly
     public static void sendWelcomeMessage(Player player) {
-        if (VelocityAutoReconnect.getConfigurationManager().getBooleanProperty("message.enabled")) {
-            player.sendMessage(Component.text(VelocityAutoReconnect.getConfigurationManager().getProperty("message")));
-        }
+        if (!VelocityAutoReconnect.getConfigurationManager().getBooleanProperty("message.enabled")) return;
+
+        // Get the message text from the config
+        var message = VelocityAutoReconnect.getConfigurationManager().getProperty("message");
+
+        // Try to deserialize message as JSON text, or use 'message' value as plain text
+        player.sendMessage(GsonComponentSerializer.gson().deserializeOr(message, Component.text(message)));
     }
 
     public static RegisteredServer getServerByName(String serverName) {

--- a/src/de/flori4nk/velocityautoreconnect/misc/Utility.java
+++ b/src/de/flori4nk/velocityautoreconnect/misc/Utility.java
@@ -40,7 +40,7 @@ public class Utility {
         var message = VelocityAutoReconnect.getConfigurationManager().getProperty("message");
 
         // Try to deserialize message as JSON text, or use 'message' value as plain text
-        player.sendMessage(GsonComponentSerializer.gson().deserializeOr(message, Component.text(message)));
+        player.sendMessage(deserializeAsJson(message));
     }
 
     public static RegisteredServer getServerByName(String serverName) {
@@ -63,5 +63,18 @@ public class Utility {
             VelocityAutoReconnect.getLogger().info(message);
         }
     }
+
+	/**
+	 * Attempts to deserialize a string as a JSON component. If it is not a valid JSON component, it will be returned as a plain text component.
+	 * @param input The input string to deserialize.
+	 * @return The deserialized component.
+	 */
+	public static Component deserializeAsJson(String input) {
+		try {
+			return GsonComponentSerializer.gson().deserialize(input);
+		} catch (Exception e) {
+			return Component.text(input);
+		}
+	}
 
 }


### PR DESCRIPTION
This PR adds a `message` setting support for JSON text. Example of JSON text:
```jsonc
["","Normal text, ",{"text":"bold red text with hover.","bold":true,"italic":true,"color":"dark_red","hoverEvent":{"action":"show_text","contents":[{"text":"Hover!","bold":true,"italic":true,"color":"aqua"}]}}]
```