### PR TITLE
Support for welcome title messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ After following the installation guide, edit the configuration file: ``plugins/v
 **message.enabled**
 * Default: false
 
+**title-text**
+* Default: Welcome to Limbo!
+* Description: Welcome title message (shown at the center of the screen) sent to players joining the Limbo server. Can be a JSON Text Component.
+
+**title-subtitle**
+* Default: You will be reconnected soon.
+* Description: Subtitle for the `title-text` setting. Can be a JSON Text Component. Can be empty.
+
+**title.enabled**
+* Default: false
+
 ##### Logging
 **log.informational**
 * Default: true

--- a/src/de/flori4nk/velocityautoreconnect/listeners/ConnectionListener.java
+++ b/src/de/flori4nk/velocityautoreconnect/listeners/ConnectionListener.java
@@ -67,6 +67,7 @@ public class ConnectionListener {
         if (Utility.doServerNamesMatch(currentServerConnection.getServer(), VelocityAutoReconnect.getLimboServer())) {
             VelocityAutoReconnect.getPlayerManager().addPlayer(player, previousServer);
             Utility.sendWelcomeMessage(player);
+            Utility.sendWelcomeTitleMessage(player);
         }
     }
 

--- a/src/de/flori4nk/velocityautoreconnect/misc/Utility.java
+++ b/src/de/flori4nk/velocityautoreconnect/misc/Utility.java
@@ -21,6 +21,8 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import de.flori4nk.velocityautoreconnect.VelocityAutoReconnect;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.title.Title;
 
 import java.util.Optional;
 
@@ -36,6 +38,26 @@ public class Utility {
         if (VelocityAutoReconnect.getConfigurationManager().getBooleanProperty("message.enabled")) {
             player.sendMessage(Component.text(VelocityAutoReconnect.getConfigurationManager().getProperty("message")));
         }
+    }
+
+    /**
+     * Sends a Title message to a player, if configured.
+     * @param player Player that will see the Title message.
+     */
+    public static void sendWelcomeTitleMessage(Player player) {
+        if (!VelocityAutoReconnect.getConfigurationManager().getBooleanProperty("title.enabled")) return;
+
+		// Get the title text values from config
+        var cfgManager = VelocityAutoReconnect.getConfigurationManager();
+        var titleText = cfgManager.getProperty("title-text");
+        var subtitleText = cfgManager.getProperty("title-subtitle");
+
+		// Deserialize the title text values
+        Component mainTitle = GsonComponentSerializer.gson().deserializeOr(titleText, Component.text(titleText));
+        Component subtitle = GsonComponentSerializer.gson().deserializeOr(subtitleText, Component.text(subtitleText));
+
+		// Show a title to a player
+        player.showTitle(Title.title(mainTitle, subtitle));
     }
 
     public static RegisteredServer getServerByName(String serverName) {

--- a/src/de/flori4nk/velocityautoreconnect/misc/Utility.java
+++ b/src/de/flori4nk/velocityautoreconnect/misc/Utility.java
@@ -53,8 +53,8 @@ public class Utility {
         var subtitleText = cfgManager.getProperty("title-subtitle");
 
 		// Deserialize the title text values
-        Component mainTitle = GsonComponentSerializer.gson().deserializeOr(titleText, Component.text(titleText));
-        Component subtitle = GsonComponentSerializer.gson().deserializeOr(subtitleText, Component.text(subtitleText));
+        Component mainTitle = deserializeAsJson(titleText);
+        Component subtitle = deserializeAsJson(subtitleText);
 
 		// Show a title to a player
         player.showTitle(Title.title(mainTitle, subtitle));
@@ -80,5 +80,18 @@ public class Utility {
             VelocityAutoReconnect.getLogger().info(message);
         }
     }
+
+	/**
+	 * Attempts to deserialize a string as a JSON component. If it is not a valid JSON component, it will be returned as a plain text component.
+	 * @param input The input string to deserialize.
+	 * @return The deserialized component.
+	 */
+	public static Component deserializeAsJson(String input) {
+		try {
+			return GsonComponentSerializer.gson().deserialize(input);
+		} catch (Exception e) {
+			return Component.text(input);
+		}
+	}
 
 }

--- a/src/de/flori4nk/velocityautoreconnect/storage/ConfigurationManager.java
+++ b/src/de/flori4nk/velocityautoreconnect/storage/ConfigurationManager.java
@@ -49,6 +49,9 @@ public class ConfigurationManager {
             this.properties.setProperty("kick-filter.whitelist.enabled", "false");
             this.properties.setProperty("message", "You will be reconnected soon.");
             this.properties.setProperty("message.enabled", "false");
+            this.properties.setProperty("title-text", "Welcome to Limbo!");
+            this.properties.setProperty("title-subtitle", "You will be reconnected soon.");
+            this.properties.setProperty("title.enabled", "false");
             this.properties.setProperty("log.informational", "true");
 
             // Load saved values


### PR DESCRIPTION
This PR adds support for welcome title messages:
![image](https://user-images.githubusercontent.com/66683075/208923237-53210e16-94ba-4f33-96ad-ccdbf247c1c6.png)

This PR also adds those settings:
**title-text**
* Default: Welcome to Limbo!
* Description: Welcome title message (shown at the center of the screen) sent to players joining the Limbo server. Can be a JSON Text Component.

**title-subtitle**
* Default: You will be reconnected soon.
* Description: Subtitle for the `title-text` setting. Can be a JSON Text Component. Can be empty.

**title.enabled**
* Default: false