### PR TITLE
fix: Permission check for bypassing auto reconnect

### DIFF
--- a/src/de/flori4nk/velocityautoreconnect/VelocityAutoReconnect.java
+++ b/src/de/flori4nk/velocityautoreconnect/VelocityAutoReconnect.java
@@ -110,6 +110,10 @@ public class VelocityAutoReconnect {
             if (connectedPlayers.isEmpty()) return;
             
             Player nextPlayer = connectedPlayers.iterator().next();
+                    if (VelocityAutoReconnect.getConfigurationManager().getBooleanProperty("bypasscheck")
+                            && nextPlayer.hasPermission("velocityautoreconnect.bypass")) {
+                        return;
+                    }
             RegisteredServer previousServer = playerManager.getPreviousServer(nextPlayer);
 
             // If enabled, check if a server responds to pings before connecting


### PR DESCRIPTION
The permission check was missing in the timed reconnect, that is why it was broken.